### PR TITLE
[ISSUE 13] FrozenRouter를 사용하여 page transition으로 일어나던 버그 수정

### DIFF
--- a/caffhheiene/src/app/client.tsx
+++ b/caffhheiene/src/app/client.tsx
@@ -1,30 +1,34 @@
 'use client';
 import { AnimatePresence, motion } from 'framer-motion';
+import { LayoutRouterContext } from 'next/dist/shared/lib/app-router-context';
 import { usePathname } from 'next/navigation';
-import { type ReactNode } from 'react';
+import { type PropsWithChildren, type ReactNode, useContext, useRef } from 'react';
 
 interface TransitionDivProps {
   children: ReactNode;
+}
+
+function FrozenRouter(props: PropsWithChildren) {
+  const context = useContext(LayoutRouterContext);
+  const frozen = useRef(context).current;
+
+  return (
+    <LayoutRouterContext.Provider value={frozen}>{props.children}</LayoutRouterContext.Provider>
+  );
 }
 
 export default function Client({ children }: TransitionDivProps) {
   const pathName = usePathname();
 
   return (
-    <AnimatePresence
-      initial
-      mode="wait"
-      onExitComplete={() => {
-        window.scrollTo(0, 0);
-      }}
-    >
+    <AnimatePresence initial mode="wait">
       <motion.div
         key={pathName}
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ duration: 1 }}
       >
-        {children}
+        <FrozenRouter>{children}</FrozenRouter>
       </motion.div>
     </AnimatePresence>
   );


### PR DESCRIPTION
### 작업 완료 목록
1. FrozenRouter를 사용하여 page transition 효과와 충돌하여 페이지가 infinite get loop에 빠지던 문제 수정 [참고 링크](https://github.com/vercel/next.js/issues/49279#issuecomment-1675393849)