### PR TITLE
[ISSUE #26] 카드 컴포넌트의 크기 고정

### DIFF
--- a/caffhheiene/src/components/Card.tsx
+++ b/caffhheiene/src/components/Card.tsx
@@ -11,9 +11,9 @@ export default function Card({ id, post }: CardComponentProps) {
   return (
     <Link href={`/posts/detail/${id + 1}`}>
       <div className="max-h-sm grid max-w-md overflow-hidden rounded-md bg-white_hover shadow-lg transition  ease-in hover:-translate-y-2">
-        <div className="grid">
+        <div className="grid h-[15rem]">
           <img
-            className="border-b object-cover"
+            className="h-full border-b object-cover"
             src={post.thumbnail}
             alt="sample"
           />


### PR DESCRIPTION
### 작업 완료 목록
1. 카드 컴포넌트의 썸네일 높이 사이즈를 고정 픽셀로 지정